### PR TITLE
 minor change to the `views/apiRegistration.hbs`

### DIFF
--- a/views/apiRegistration.hbs
+++ b/views/apiRegistration.hbs
@@ -204,7 +204,7 @@
                           </div>
                           <div>
                             <strong class="text-customEight">Option 2 - Country Code:</strong><br>
-                            <code class="text-customEight">country</code> <span class="text-gray-400">(required)</span> - ISO country code (e.g., "DE", "US", "FR")
+                            <code class="text-customEight">countryCode</code> <span class="text-gray-400">(required)</span> - ISO country code (e.g., "DE", "US", "FR")
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
This pull request makes a minor change to the `views/apiRegistration.hbs` file, updating the documentation to refer to the `countryCode` parameter instead of `country` for the ISO country code field.